### PR TITLE
商品削除機能の導入

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -34,6 +34,10 @@ class ProductsController < ApplicationController
     end
   end
 
+  def destroy
+    
+  end
+
   private
 
   def product_params

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -35,7 +35,9 @@ class ProductsController < ApplicationController
   end
 
   def destroy
-    
+    product = Product.find(params[:id])
+    product.destroy
+    redirect_to root_path
   end
 
   private

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -1,7 +1,7 @@
 class ProductsController < ApplicationController
   before_action :authenticate_user!, only: [:new, :edit]
   before_action :set_product, only: [:show, :edit, :update]
-  before_action :move_to_index, only: :edit
+  before_action :move_to_index, only: [:edit, :destroy]
 
   def index
     @products = Product.includes(:user).order('created_at DESC')
@@ -35,8 +35,7 @@ class ProductsController < ApplicationController
   end
 
   def destroy
-    product = Product.find(params[:id])
-    product.destroy
+    @product.destroy
     redirect_to root_path
   end
 

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -25,7 +25,7 @@
     <% if user_signed_in? && current_user.id == @product.user_id %>
       <%= link_to "商品の編集", edit_product_path(params[:id]), method: :get, class: "item-red-btn" %>
       <p class="or-text">or</p>
-      <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
+      <%= link_to "削除", product_path(params[:id]), method: :delete, class:"item-destroy" %>
     <% elsif user_signed_in? && current_user.id != @product.user_id %>
       <%# 商品が売れていない場合はこちらを表示しましょう %>
       <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,5 +3,5 @@ Rails.application.routes.draw do
 
   root 'products#index'
 
-  resources :products, only: [:index, :new, :create, :show, :edit, :update]
+  resources :products
 end


### PR DESCRIPTION
# What
商品削除機能の作成

# Why
商品削除機能の実装のため

# ログイン状態の出品者が商品を削除したとき
https://gyazo.com/d5c769465740be76e3ccabbfa7109dc3